### PR TITLE
Allow use of Berryterminal with other languages

### DIFF
--- a/buildroot/package/ldm/S99ltsp
+++ b/buildroot/package/ldm/S99ltsp
@@ -30,6 +30,7 @@ case "$1" in
     echo "" >/etc/resolv.conf
    
     # If there is a "server=1.2.3.4" kernel parameter use that instead
+    # Allow the default language to be overridden too.
     for x in `cat /proc/cmdline`
     do
         case $x in
@@ -41,6 +42,11 @@ case "$1" in
             ;;
             LDM*)
             export $x
+            ;;
+            LANG=*)
+            export LANG=${x//LANG=}
+            export LANGUAGE=${x//LANG=}
+            export LDM_LANGUAGE=${x//LANG=}
             ;;
         esac
     done


### PR DESCRIPTION
Just a tiny change which allows the language used by ldm to be changed on the kernel command line.  This means it can be re-configured in 20 seconds instead of requiring a one and half hour re-build.

Add, for example LANG=en_GB.UTF-8 in cmdline.txt and it then uses that locale instead of the existing hardcoded USA one.
